### PR TITLE
Revert "Added missing prereq Moo::Role as reported by CPANTS."

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -41,7 +41,6 @@ OpenStack::Client           = 1.0006
 YAML::XS                    = 0
 JSON                        = 0
 Moo                         = 0
-Moo::Role                   = 0
 
 ;[Prereqs / TestRecommends]
 [Prereqs / TestRequires]


### PR DESCRIPTION
Reverts atoomic/OpenStack-MetaAPI#1

Moo::Role is provided by Moo which was already added as dependencies as part of eee431fd97ea5e54b24ff558a04aa5169653e6b6